### PR TITLE
implementation of get_dipole_moment() function in ase interface

### DIFF
--- a/aimnet2calc/aimnet2ase.py
+++ b/aimnet2calc/aimnet2ase.py
@@ -85,8 +85,7 @@ class AIMNet2ASE(Calculator):
         for k, v in results.items():
             results[k] = v.detach().cpu().numpy()
 
-        # ase expects us to return a scalar
-        self.results['energy'] = results['energy'][0]
+        self.results['energy'] = results['energy'].item()
         self.results['charges'] = results['charges']
         self.results['dipole_moment'] = self.get_dipole_moment(self.atoms)
 

--- a/aimnet2calc/nblist.py
+++ b/aimnet2calc/nblist.py
@@ -134,12 +134,12 @@ def _nblist_pbc_cuda(conn_mat, shifts):
     return idx_j, mat_pad, shifts[S_idx]
 
 
-def _nblist_pbc_cpu(conn_mat, shifts, device):
+def _nblist_pbc_cpu(conn_mat, shifts):
     conn_mat = conn_mat.cpu().numpy()
     mat_idxj, mat_pad, mat_S_idx = _cpu_dense_nb_mat_sft(conn_mat)
-    mat_idxj = torch.from_numpy(mat_idxj).to(device)
-    mat_pad = torch.from_numpy(mat_pad).to(device)
-    mat_S_idx = torch.from_numpy(mat_S_idx).to(device)
+    mat_idxj = torch.from_numpy(mat_idxj).cpu()
+    mat_pad = torch.from_numpy(mat_pad).cpu()
+    mat_S_idx = torch.from_numpy(mat_S_idx).cpu()
     mat_S = shifts[mat_S_idx]
     return mat_idxj, mat_pad, mat_S
 

--- a/aimnet2calc/nblist.py
+++ b/aimnet2calc/nblist.py
@@ -137,9 +137,9 @@ def _nblist_pbc_cuda(conn_mat, shifts):
 def _nblist_pbc_cpu(conn_mat, shifts):
     conn_mat = conn_mat.cpu().numpy()
     mat_idxj, mat_pad, mat_S_idx = _cpu_dense_nb_mat_sft(conn_mat)
-    mat_idxj = torch.from_numpy(mat_idxj).cpu()
-    mat_pad = torch.from_numpy(mat_pad).cpu()
-    mat_S_idx = torch.from_numpy(mat_S_idx).cpu()
+    mat_idxj = torch.from_numpy(mat_idxj)
+    mat_pad = torch.from_numpy(mat_pad)
+    mat_S_idx = torch.from_numpy(mat_S_idx)
     mat_S = shifts[mat_S_idx]
     return mat_idxj, mat_pad, mat_S
 

--- a/test/test_ase.py
+++ b/test/test_ase.py
@@ -28,12 +28,15 @@ def _test_dipole(calc, atoms):
     atoms.calc = calc
     e =atoms.get_potential_energy()
     assert e.shape == ()
-    assert e < 0.0
 
+    assert hasattr(atoms, 'get_charges')
+    q = atoms.get_charges()
+    assert q.shape == (len(atoms),)
+    
+    assert hasattr(atoms, 'get_dipole_moment')
     dm = atoms.get_dipole_moment()
     assert dm.shape == (3,)
-    assert np.linalg.norm(dm) > 0.0
-
+    
 
 def test_calculator():
     for model in MODELS:

--- a/test/test_ase.py
+++ b/test/test_ase.py
@@ -1,0 +1,50 @@
+import os
+
+import ase
+import numpy as np
+
+from aimnet2calc.aimnet2ase import AIMNet2ASE
+
+MODELS = ('aimnet2', 'aimnet2_b973c')
+DIR = os.path.dirname(__file__)
+
+
+def _struct_pbc():
+    filename = os.path.join(DIR, '1008775.cif')
+    return ase.io.read(filename)
+
+
+def _struct_list():
+    filename = os.path.join(DIR, 'mols_size_var.xyz')
+    return ase.io.read(filename, index=':')
+
+
+def _stuct_batch():
+    filename = os.path.join(DIR, 'mols_size_36.xyz')
+    return ase.io.read(filename, index=':')
+
+
+def _test_dipole(calc, atoms):
+    atoms.calc = calc
+    e =atoms.get_potential_energy()
+    assert e.shape == ()
+    assert e < 0.0
+
+    dm = atoms.get_dipole_moment()
+    assert dm.shape == (3,)
+    assert np.linalg.norm(dm) > 0.0
+
+
+def test_calculator():
+    for model in MODELS:
+        print('Testing model:', model)
+        calculator = AIMNet2ASE(model)
+        for atoms_list, runtype in zip((_stuct_batch(), _struct_list(), _struct_pbc()), ('batch', 'list', 'pbc')):
+            if runtype == 'batch' or runtype == 'list':
+                for atoms in atoms_list:
+                    _test_dipole(calculator, atoms)
+
+            else:
+                _test_dipole(calculator, atoms_list)
+
+

--- a/test/test_ase.py
+++ b/test/test_ase.py
@@ -27,7 +27,7 @@ def _stuct_batch():
 def _test_dipole(calc, atoms):
     atoms.calc = calc
     e =atoms.get_potential_energy()
-    assert e.shape == ()
+    assert isinstance(e, float)
 
     assert hasattr(atoms, 'get_charges')
     q = atoms.get_charges()

--- a/test/test_calculator.py
+++ b/test/test_calculator.py
@@ -1,8 +1,9 @@
-import ase.io
-from aimnet2calc.calculator import AIMNet2Calculator
 import os
+
+import ase.io
 import numpy as np
 
+from aimnet2calc.calculator import AIMNet2Calculator
 
 MODELS = ('aimnet2', 'aimnet2_b973c')
 DIR = os.path.dirname(__file__)


### PR DESCRIPTION
This change allows for obtaining the dipole moment from the computed charges and hence for the computation of IR intensities, obtaining nice spectra via the ASE vibrations module: https://wiki.fysik.dtu.dk/ase/ase/vibrations/infrared.html
It also adds a small test, and fixes a minor bug in get_potential_energy() function returning the wrong shape and missing argument in _nblist_pbc_cpu.